### PR TITLE
Fix Makefile for Azure path to quote lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ App_Name := attestor
 
 ######## Verifier Settings ########
 DCAP_lib_path := /usr/lib/x86_64-linux-gnu
-ifneq ("$(wildcard $(DCAP_lib_path)/libdcap_quoteverify)","")
+ifneq ("$(wildcard $(DCAP_lib_path)/libdcap_quoteverify.so)","")
 	DCAP_lib_name := dcap_quoteverify
 else
 	DCAP_lib_name := sgx_dcap_quoteverify


### PR DESCRIPTION
Checking for existence of quote verification library was missing .so extension in file name.
i.e. libdcap_quoteverify is libdcap_quoteverify.so

Signed-off-by: Dan Middleton <dan.middleton@intel.com>