### PR TITLE
Upgrade to SGX SDK 2.9 and libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,9 @@ App_Cpp_Flags := $(App_C_Flags) -std=c++11
 App_Link_Flags := $(SGX_COMMON_CFLAGS) -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name) -lpthread 
 
 ifneq ($(SGX_MODE), HW)
-	App_Link_Flags += -lsgx_uae_service_sim
+	App_Link_Flags += -lsgx_quote_ex_sim
 else
-	App_Link_Flags += -lsgx_uae_service
+	App_Link_Flags += -lsgx_quote_ex
 endif
 
 App_Cpp_Objects := $(App_Cpp_Files:.cpp=.o)

--- a/README.md
+++ b/README.md
@@ -183,13 +183,21 @@ However if you build in HW mode the binary will work on Ubuntu natively.)
     `apt-get update && apt-get upgrade`
 
 1. Install the Intel(r) SGX SDK
+
 ```
-    wget \
-       https://download.01.org/intel-sgx/sgx-linux/2.7.1/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.7.101.3.bin \
-       && chmod +x sgx_linux_x64_sdk_2.7.101.3.bin \
-       && echo "yes" | ./sgx_linux_x64_sdk_2.7.101.3.bin \
-       && rm sgx_linux_x64_sdk_2.7.101.3.bin \
-       && echo "source /opt/intel/sgxsdk/environment" >> /etc/environment`
+    sudo wget \
+        https://download.01.org/intel-sgx/sgx-linux/2.9/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.9.100.2.bin \
+        && sudo chmod +x sgx_linux_x64_sdk_2.9.100.2.bin \
+        && echo "yes" | sudo ./sgx_linux_x64_sdk_2.9.100.2.bin \
+        && sudo rm sgx_linux_x64_sdk_2.9.100.2.bin \
+        && sudo ln -s /opt/intel/sgxsdk/lib64/libsgx_quote_ex_sim.so /opt/intel/sgxsdk/sdk_libs/ \
+        && sudo sh -c 'echo ". /opt/intel/sgxsdk/environment" >> /etc/environment' 
+```
+
+1. Install the runtime quote (attestation) libraries
+
+```
+    sudo apt-get install libsgx-quote-ex
 ```
 
 1. Set library search order to pick up Azure's quote provider library rather

--- a/docker/dev-env
+++ b/docker/dev-env
@@ -42,17 +42,18 @@ RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bio
 RUN wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
 RUN apt-get update 
 
-# Install SGX common library
-RUN apt-get install -y -q libsgx-enclave-common
+# Install SGX runtime components
+RUN apt-get install -y -q libsgx-quote-ex libsgx-urts
 
 # SGX SDK is installed in /opt/intel directory.
 WORKDIR /opt/intel
 
 # Install SGX SDK
-RUN wget https://download.01.org/intel-sgx/sgx-linux/2.7.1/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.7.101.3.bin \ 
- && chmod +x sgx_linux_x64_sdk_2.7.101.3.bin \
- && echo "yes" | ./sgx_linux_x64_sdk_2.7.101.3.bin \
- && rm sgx_linux_x64_sdk_2.7.101.3.bin \
+RUN wget https://download.01.org/intel-sgx/sgx-linux/2.9/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.9.100.2.bin \
+ && chmod +x sgx_linux_x64_sdk_2.9.100.2.bin \
+ && echo "yes" | ./sgx_linux_x64_sdk_2.9.100.2.bin \
+ && rm sgx_linux_x64_sdk_2.9.100.2.bin \
+ && ln -s /opt/intel/sgxsdk/lib64/libsgx_quote_ex_sim.so /opt/intel/sgxsdk/sdk_libs/ \
  && echo ". /opt/intel/sgxsdk/environment" >> /etc/environment
 
 # Install SGX DCAP SDK


### PR DESCRIPTION
Removes requirement for UAE Service, using the more granular libraries
instead (e.g. libsgx-quote-ex).

Signed-off-by: Dan Middleton <dan.middleton@intel.com>