### PR TITLE
Remove azure QvL condition from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,7 @@ App_Name := attestor
 
 ######## Verifier Settings ########
 DCAP_lib_path := /usr/lib/x86_64-linux-gnu
-ifneq ("$(wildcard $(DCAP_lib_path)/libdcap_quoteverify.so)","")
-	DCAP_lib_name := dcap_quoteverify
-else
-	DCAP_lib_name := sgx_dcap_quoteverify
-endif
+DCAP_lib_name := sgx_dcap_quoteverify
 Verifier_Include_Paths := -IInclude -I$(SGX_SDK)/include
 Verifier_Link_Flags := -L$(DCAP_lib_path) -l$(DCAP_lib_name) $(SGX_COMMON_CFLAGS) -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name)
 Verifier_Cpp_Flags := $(Verifier_Include_Paths) -std=c++11


### PR DESCRIPTION
libdcap_quoteverify.so does not exist anymore. Just use the reference
verification lib, libsgx_dcap_quoteverify.so.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>